### PR TITLE
Add NPM_FLAGS for build

### DIFF
--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -7,8 +7,9 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+ARG NPM_FLAGS=""
 COPY package.json ./
-RUN npm install
+RUN npm install ${NPM_FLAGS}
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
Allow to ignore ssl verification for build:
docker compose build --build-arg  NPM_FLAGS="--strict-ssl=false" docker compose up -d