### PR TITLE
Tighten Task access control; drop unused smart-* scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,13 +838,10 @@ Every M2M token (L1 and L2) includes the following hardcoded claims — identica
 
 #### Client Scopes
 
+SMART `system/<Resource>.<perms>` scopes (Task.cru, Patient.r, ServiceRequest.r/.rs, Condition.r, Observation.r, …) are assigned as **default** scopes per M2M client and bundled into every issued token. They are the substrate read by OPA's `has_smart_scope` check (`services/opa/policies/main.rego`).
+
 | Scope Name | Type | Description |
 |------------|------|-------------|
-| `smart-patient-read` | Static | Adds `system/Patient.r` to token |
-| `smart-task-write` | Static | SMART Task create/update permission |
-| `smart-servicerequest-read` | Static | SMART ServiceRequest read |
-| `smart-clinical-read` | Static | Conditions, medications, allergies, etc. |
-| `smart-questionnaire-write` | Static | QuestionnaireResponse create/update |
 | **`consent`** | **Dynamic** | **Parameterised consent scope (see below)** |
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,6 +250,7 @@ services:
       - ./services/apisix/external/config.yaml:/usr/local/apisix/conf/config.yaml:ro
       - ./services/apisix/external/apisix.yaml:/templates/apisix.yaml:ro
       - ./services/apisix/entrypoint.sh:/entrypoint.sh:ro
+      - ./services/apisix/plugins/umzh-task-requester-inject.lua:/usr/local/apisix/apisix/plugins/umzh-task-requester-inject.lua:ro
     ports:
       - '${APISIX_PLACER_EXTERNAL_PORT}:9080'
     depends_on:
@@ -330,6 +331,7 @@ services:
       - ./services/apisix/external/config.yaml:/usr/local/apisix/conf/config.yaml:ro
       - ./services/apisix/external/apisix.yaml:/templates/apisix.yaml:ro
       - ./services/apisix/entrypoint.sh:/entrypoint.sh:ro
+      - ./services/apisix/plugins/umzh-task-requester-inject.lua:/usr/local/apisix/apisix/plugins/umzh-task-requester-inject.lua:ro
     ports:
       - '${APISIX_FULFILLER_EXTERNAL_PORT}:9080'
     depends_on:

--- a/services/apisix/external/apisix.yaml
+++ b/services/apisix/external/apisix.yaml
@@ -32,7 +32,11 @@ routes:
     priority: 100
     upstream_id: jwks-${PARTY}
 
-  # ─── Task list — JWT only, no OPA (workflow resource) ────────────────
+  # ─── Task list — JWT + scope (system/Task.s) + server-side requester filter ─
+  # Scope-gated to require .s, and the umzh-task-requester-inject plugin appends
+  # ?requester=<organization_reference> from the caller's token so HAPI only
+  # returns Tasks where the caller is the named requester. The caller cannot
+  # override this filter — args.requester is set after the request is parsed.
   - id: ext-task-list
     uri: /fhir/Task
     methods: [GET]
@@ -47,6 +51,10 @@ routes:
         set_userinfo_header: false
         client_id: "unused"
         client_secret: "unused"
+      opa:
+        host: "http://opa-${PARTY}:8181"
+        policy: "umzh/authz/apisix"
+      umzh-task-requester-inject: {}
       proxy-rewrite:
         uri: /fhir/${PARTY}/Task
 

--- a/services/apisix/external/config.yaml
+++ b/services/apisix/external/config.yaml
@@ -2,6 +2,19 @@ apisix:
   node_listen: 9080
   enable_ipv6: false
 
+# Explicit plugin list: APISIX disables non-default plugins unless enumerated
+# here. Required to load the custom umzh-task-requester-inject plugin alongside
+# the built-ins used by routes.
+plugins:
+  - cors
+  - openid-connect
+  - opa
+  - proxy-rewrite
+  - response-rewrite
+  - serverless-pre-function
+  - serverless-post-function
+  - umzh-task-requester-inject
+
 deployment:
   role: data_plane
   role_data_plane:

--- a/services/apisix/plugins/umzh-task-requester-inject.lua
+++ b/services/apisix/plugins/umzh-task-requester-inject.lua
@@ -1,0 +1,69 @@
+-- umzh-task-requester-inject.lua
+-- Injects a `requester=<organization_reference>` FHIR search parameter into the
+-- upstream URL, populated from the caller's JWT claim
+-- $.extensions.umzhconnect.organization_reference.
+--
+-- Mounted on the external gateway's /fhir/Task list route so HAPI returns only
+-- Tasks for which the calling party is named as the requester. Combined with the
+-- OPA scope check on the same route (require system/Task.s), this gives:
+--   * scope-gated:   caller must hold .s permission
+--   * server-side filtered: caller cannot see Tasks belonging to other requesters
+--
+-- The JWT signature is verified by the `openid-connect` plugin on the same
+-- route, which runs in the access phase at priority 2599. This plugin runs in
+-- the same phase at priority 999, so by the time it executes the bearer has
+-- already been validated. (If validation fails, openid-connect aborts the
+-- request with 401 before this plugin's set_uri_args call would matter.)
+--
+-- io.jwt.decode is not used here because resty.jwt's dependency chain is heavy
+-- for what is a parse-only operation. The signed JWT's middle segment is
+-- base64url-decoded inline; we trust the signature check done upstream.
+
+local plugin_name = "umzh-task-requester-inject"
+local cjson = require("cjson.safe")
+
+local _M = {
+  version  = 0.1,
+  priority = 999,
+  name     = plugin_name,
+  schema   = { type = "object", properties = {} },
+}
+
+local function b64url_decode(s)
+  s = s:gsub("-", "+"):gsub("_", "/")
+  local rem = #s % 4
+  if rem > 0 then s = s .. string.rep("=", 4 - rem) end
+  return ngx.decode_base64(s)
+end
+
+function _M.access(conf, ctx)
+  local auth = ngx.req.get_headers()["authorization"] or ""
+  local tok  = auth:match("^Bearer%s+(.+)$")
+  if not tok then return end
+
+  local _, payload_b64 = tok:match("([^%.]+)%.([^%.]+)")
+  if not payload_b64 then return end
+
+  local payload_json = b64url_decode(payload_b64)
+  if not payload_json then return end
+
+  local payload = cjson.decode(payload_json)
+  if not payload then return end
+
+  local ext = payload.extensions
+  local umzh = ext and ext.umzhconnect
+  local org_ref = umzh and umzh.organization_reference
+  if not org_ref or org_ref == "" then return end
+
+  -- proxy-rewrite (rewrite phase) has already overwritten the upstream path
+  -- to /fhir/<party>/Task via ctx.var.upstream_uri. We append the requester
+  -- search parameter directly on that variable — set_uri_args at access phase
+  -- mutates the inbound request's args but APISIX doesn't re-derive
+  -- upstream_uri from them after proxy-rewrite, so the inbound mutation is
+  -- silently dropped.
+  local cur = ctx.var.upstream_uri or ngx.var.upstream_uri or ""
+  local sep = cur:find("?", 1, true) and "&" or "?"
+  ctx.var.upstream_uri = cur .. sep .. "requester=" .. ngx.escape_uri(org_ref)
+end
+
+return _M

--- a/services/keycloak/realm-export.json
+++ b/services/keycloak/realm-export.json
@@ -32,58 +32,7 @@
   "scopeMappings": [],
   "clientScopes": [
     {
-      "name": "smart-patient-read",
-      "description": "SMART on FHIR: Read patient data",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "Read patient demographic data"
-      },
-      "protocolMappers": []
-    },
-    {
-      "name": "smart-task-write",
-      "description": "SMART on FHIR: Create/update tasks",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "Create and update task resources"
-      }
-    },
-    {
-      "name": "smart-servicerequest-read",
-      "description": "SMART on FHIR: Read service requests",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "Read service request data"
-      }
-    },
-    {
-      "name": "smart-clinical-read",
-      "description": "SMART on FHIR: Read clinical resources (conditions, medications, allergies, etc.)",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "Read clinical data (conditions, medications, allergies)"
-      }
-    },
-    {
-      "name": "smart-questionnaire-write",
-      "description": "SMART on FHIR: Create/update questionnaire responses",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "Create and update questionnaire responses"
-      }
-    },
-    {
-      "name": "system/Task.cru",
+      "name": "system/Task.crus",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true"
@@ -240,13 +189,7 @@
         "http://localhost:8080"
       ],
       "defaultClientScopes": [],
-      "optionalClientScopes": [
-        "smart-patient-read",
-        "smart-task-write",
-        "smart-servicerequest-read",
-        "smart-clinical-read",
-        "smart-questionnaire-write"
-      ],
+      "optionalClientScopes": [],
       "protocolMappers": [
         {
           "name": "realm-roles",
@@ -279,7 +222,7 @@
         "http://localhost:3000"
       ],
       "defaultClientScopes": [
-        "system/Task.cru",
+        "system/Task.crus",
         "system/ServiceRequest.rs",
         "system/Patient.r",
         "system/Condition.r",
@@ -293,12 +236,7 @@
         "system/QuestionnaireResponse.cru",
         "system/ImagingStudy.r"
       ],
-      "optionalClientScopes": [
-        "smart-task-write",
-        "smart-servicerequest-read",
-        "smart-clinical-read",
-        "smart-questionnaire-write"
-      ],
+      "optionalClientScopes": [],
       "protocolMappers": [
         {
           "name": "org-reference-mapper",
@@ -367,7 +305,7 @@
         "http://localhost:3000"
       ],
       "defaultClientScopes": [
-        "system/Task.cru",
+        "system/Task.crus",
         "system/ServiceRequest.r",
         "system/Patient.r",
         "system/Condition.r",
@@ -384,13 +322,7 @@
         "system/Practitioner.r",
         "system/PractitionerRole.r"
       ],
-      "optionalClientScopes": [
-        "smart-task-write",
-        "smart-servicerequest-read",
-        "smart-clinical-read",
-        "smart-patient-read",
-        "smart-questionnaire-write"
-      ],
+      "optionalClientScopes": [],
       "protocolMappers": [
         {
           "name": "org-reference-mapper",
@@ -462,7 +394,7 @@
         "http://localhost:3000"
       ],
       "defaultClientScopes": [
-        "system/Task.cru",
+        "system/Task.crus",
         "system/ServiceRequest.rs",
         "system/Patient.r",
         "system/Condition.r",
@@ -476,12 +408,7 @@
         "system/QuestionnaireResponse.cru",
         "system/ImagingStudy.r"
       ],
-      "optionalClientScopes": [
-        "smart-task-write",
-        "smart-servicerequest-read",
-        "smart-clinical-read",
-        "smart-questionnaire-write"
-      ],
+      "optionalClientScopes": [],
       "protocolMappers": [
         {
           "name": "org-reference-mapper",
@@ -553,7 +480,7 @@
         "http://localhost:3000"
       ],
       "defaultClientScopes": [
-        "system/Task.cru",
+        "system/Task.crus",
         "system/ServiceRequest.r",
         "system/Patient.r",
         "system/Condition.r",
@@ -570,13 +497,7 @@
         "system/Practitioner.r",
         "system/PractitionerRole.r"
       ],
-      "optionalClientScopes": [
-        "smart-task-write",
-        "smart-servicerequest-read",
-        "smart-clinical-read",
-        "smart-patient-read",
-        "smart-questionnaire-write"
-      ],
+      "optionalClientScopes": [],
       "protocolMappers": [
         {
           "name": "org-reference-mapper",

--- a/services/opa/policies/main.rego
+++ b/services/opa/policies/main.rego
@@ -42,7 +42,7 @@ http_status := 403 if { not allow }
 #   "resource_id": "123",
 #   "token": {
 #     "organization_reference": "http://localhost:8084/fhir/Organization/HospitalF",
-#     "scope":                  "system/Patient.r system/Task.cru ...",
+#     "scope":                  "system/Patient.r system/Task.crus ...",
 #     "fhir_context":           [{"reference": "ServiceRequest/sr-123"}]
 #   },
 #   "fhir_base": "http://nginx-proxy:81/fhir/placer"
@@ -50,10 +50,39 @@ http_status := 403 if { not allow }
 # ---------------------------------------------------------------------------
 
 # ==========================================================================
-# Rule 1: Allow Task operations (owner-based, no consent needed)
+# Rule 1a: Task search — require system/Task.s
+# ------------------------------------------------------------------------
+# The gateway also injects ?requester=<organization_reference> via the
+# umzh-task-requester-inject plugin so HAPI returns only Tasks where the
+# caller is the named requester. The scope check here gates *whether* the
+# search may run; the requester filter scopes *what it returns*.
 # ==========================================================================
 allow if {
 	input.resource_type == "Task"
+	input.method == "GET"
+	input.resource_id == ""
+	has_smart_scope("Task", "s")
+}
+
+# ==========================================================================
+# Rule 1b: Task read by id — require system/Task.r AND the fetched Task's
+# requester field must equal the calling party's organization_reference
+# ==========================================================================
+allow if {
+	input.resource_type == "Task"
+	input.method == "GET"
+	input.resource_id != ""
+	has_smart_scope("Task", "r")
+	task := fetched_task(input.resource_id)
+	task.requester.reference == input.token.organization_reference
+}
+
+# ==========================================================================
+# Rule 1c: Task create / update / delete — scope check only, no requester gate
+# ==========================================================================
+allow if {
+	input.resource_type == "Task"
+	input.method != "GET"
 	has_smart_scope("Task", method_to_action(input.method))
 }
 
@@ -179,6 +208,21 @@ consent_grants(sr_ref) if {
 # ==========================================================================
 # ServiceRequest graph — derive resource scope from a fhirContext reference
 # ==========================================================================
+
+# Fetch a Task by id from this party's partition.  Not cached: Task state
+# (and in principle Task.requester) can change; the requester check must
+# read the current value.
+fetched_task(task_id) := task if {
+	url := concat("/", [input.fhir_base, "Task", task_id])
+	resp := http.send({
+		"method":            "GET",
+		"url":               url,
+		"headers":           {"Accept": "application/fhir+json"},
+		"force_json_decode": true,
+	})
+	resp.status_code == 200
+	task := resp.body
+}
 
 # Fetch the ServiceRequest named by <sr_ref>.  Cached: a ServiceRequest is
 # immutable for the lifetime of the workflow it anchors.

--- a/services/seed/bundles/fulfiller-bundle.json
+++ b/services/seed/bundles/fulfiller-bundle.json
@@ -37,7 +37,7 @@
           "reference": "__PLACER_EXTERNAL_URL__/fhir/Patient/PetraMeier"
         },
         "requester": {
-          "reference": "__PLACER_EXTERNAL_URL__/fhir/PractitionerRole/HansMusterRole"
+          "reference": "__REGISTRY_URL__/fhir/Organization/HospitalP"
         },
         "owner": {
           "reference": "__REGISTRY_URL__/fhir/Organization/HospitalF"
@@ -62,6 +62,36 @@
       "request": {
         "method": "PUT",
         "url": "Task/TaskOrthopedicReferral"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:task-internal-lab",
+      "resource": {
+        "resourceType": "Task",
+        "id": "TaskInternalLabReview",
+        "status": "requested",
+        "intent": "order",
+        "authoredOn": "2026-01-08T09:00:00+01:00",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "385763009",
+              "display": "Internal review"
+            }
+          ],
+          "text": "Internal lab QC review — fulfiller-only workflow"
+        },
+        "requester": {
+          "reference": "__REGISTRY_URL__/fhir/Organization/HospitalF"
+        },
+        "owner": {
+          "reference": "__REGISTRY_URL__/fhir/Organization/HospitalF"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Task/TaskInternalLabReview"
       }
     }
   ]

--- a/tests/hurl/02-auth.hurl
+++ b/tests/hurl/02-auth.hurl
@@ -12,7 +12,6 @@ POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
 grant_type: client_credentials
 client_id: placer-client
 client_secret: placer-secret-2025
-scope: smart-task-write smart-servicerequest-read smart-clinical-read
 HTTP 200
 [Captures]
 placer_cc_token: jsonpath "$.access_token"
@@ -29,7 +28,6 @@ POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
 grant_type: client_credentials
 client_id: fulfiller-client
 client_secret: fulfiller-secret-2025
-scope: smart-task-write smart-servicerequest-read smart-clinical-read smart-patient-read
 HTTP 200
 [Captures]
 fulfiller_cc_token: jsonpath "$.access_token"
@@ -45,7 +43,6 @@ POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
 grant_type: client_credentials
 client_id: fulfiller-client
 client_secret: fulfiller-secret-2025
-scope: smart-patient-read smart-servicerequest-read
 authorization_details: [{"type":"umzh-connect-context","identifier":"ServiceRequest/ReferralOrthopedicSurgery"}]
 HTTP 200
 [Captures]
@@ -65,6 +62,40 @@ jsonpath "$.active" == true
 jsonpath "$.extensions.umzhconnect.organization_reference" contains "/fhir/Organization/HospitalF"
 
 
+# --- M2M with explicit system/* scope request ---
+#
+# Demonstrates the SMART Backend Services pattern: a client narrows or
+# declares intent by requesting a specific system/<Resource>.<perms> scope
+# at token time. The granted scope set is the union of the client's
+# defaultClientScopes and any explicitly-requested scopes the client is
+# entitled to. The introspection below confirms system/Patient.r lands in
+# the access token's `scope` claim — the same string OPA's has_smart_scope
+# parses.
+
+POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
+[FormParams]
+grant_type: client_credentials
+client_id: placer-client
+client_secret: placer-secret-2025
+scope: system/Patient.r
+HTTP 200
+[Captures]
+placer_scoped_token: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" exists
+jsonpath "$.scope" contains "system/Patient.r"
+
+POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token/introspect
+[FormParams]
+token: {{placer_scoped_token}}
+client_id: placer-client
+client_secret: placer-secret-2025
+HTTP 200
+[Asserts]
+jsonpath "$.active" == true
+jsonpath "$.scope" contains "system/Patient.r"
+
+
 # --- Password grant: placer-user ---
 
 POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
@@ -73,7 +104,7 @@ grant_type: password
 client_id: web-app
 username: placer-user
 password: placer123
-scope: openid smart-patient-read smart-task-write
+scope: openid
 HTTP 200
 [Asserts]
 jsonpath "$.access_token" exists
@@ -88,7 +119,7 @@ grant_type: password
 client_id: web-app
 username: fulfiller-user
 password: fulfiller123
-scope: openid smart-patient-read smart-task-write
+scope: openid
 HTTP 200
 [Asserts]
 jsonpath "$.access_token" exists

--- a/tests/hurl/11-task-requester-gate.hurl
+++ b/tests/hurl/11-task-requester-gate.hurl
@@ -1,0 +1,80 @@
+# =============================================================================
+# 11-task-requester-gate.hurl — Task requester scoping
+#
+# Verifies the two-part Task access-control regime introduced alongside the
+# system/Task.crus scope rename:
+#
+#   * /fhir/Task  GET  — scope-gated to system/Task.s, plus a server-side
+#                        ?requester=<organization_reference> filter injected
+#                        by umzh-task-requester-inject. The caller cannot
+#                        observe Tasks belonging to other requesters.
+#   * /fhir/Task/{id} GET — scope-gated to system/Task.r AND OPA verifies
+#                           Task.requester equals the caller's
+#                           organization_reference.
+#
+# Fulfiller partition is seeded with TWO Tasks:
+#   * TaskOrthopedicReferral   requester = Organization/HospitalP
+#   * TaskInternalLabReview    requester = Organization/HospitalF
+#
+# A direct HAPI query (no gateway, no auth) confirms both are present. The
+# placer-as-caller search via the external gateway must then return only the
+# first — proof that the injected ?requester=<token org_ref> actually filters.
+# The deny case at the end uses TaskInternalLabReview as the by-id read target;
+# its requester=HospitalF, placer's token says HospitalP, so OPA Rule 1b's
+# equality check fails.
+# =============================================================================
+
+
+# --- 1. Baseline: direct HAPI shows both seed Tasks in the fulfiller partition ---
+# Bypasses both external gateway and OPA, so no filter is applied. The earlier
+# 06-workflow test may have added more Tasks; we don't pin the total, only that
+# our two seed Tasks both exist.
+
+GET {{hapi_url}}/fhir/fulfiller/Task
+HTTP 200
+[Asserts]
+jsonpath "$.resourceType" == "Bundle"
+jsonpath "$.entry[*].resource.id" contains "TaskOrthopedicReferral"
+jsonpath "$.entry[*].resource.id" contains "TaskInternalLabReview"
+
+
+# --- 2. Placer searches Task list at Fulfiller's external gateway ---
+# The umzh-task-requester-inject plugin appends ?requester=<placer org_ref>
+# before forwarding to HAPI. Even though both seed Tasks (and any others left
+# by earlier tests) exist in the partition, the response must include only
+# Tasks where requester == Organization/HospitalP. Specifically:
+#   * TaskOrthopedicReferral   (requester=HospitalP) → PRESENT
+#   * TaskInternalLabReview    (requester=HospitalF) → ABSENT
+# The two contains/not-contains assertions are the end-to-end proof that the
+# injection takes effect server-side.
+
+GET {{fulfiller_ext_url}}/fhir/Task
+Authorization: Bearer {{placer_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.resourceType" == "Bundle"
+jsonpath "$.entry[*].resource.id" contains "TaskOrthopedicReferral"
+jsonpath "$.entry[*].resource.id" not contains "TaskInternalLabReview"
+
+
+# --- 3. Placer reads that Task by id (Task.requester matches → allow) ---
+
+GET {{fulfiller_ext_url}}/fhir/Task/TaskOrthopedicReferral
+Authorization: Bearer {{placer_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.resourceType" == "Task"
+jsonpath "$.id" == "TaskOrthopedicReferral"
+jsonpath "$.requester.reference" contains "/fhir/Organization/HospitalP"
+
+
+# --- 4. Placer reads TaskInternalLabReview by id (Task.requester mismatch → deny) ---
+# Same gateway, same route as test 3, same scope. The only difference is the
+# fetched Task.requester field — TaskInternalLabReview.requester is HospitalF,
+# placer's organization_reference is HospitalP. OPA Rule 1b's equality check
+# fails → default deny → 403. Note the test 2 search also confirmed the caller
+# cannot even *see* this Task in the list — defense in depth.
+
+GET {{fulfiller_ext_url}}/fhir/Task/TaskInternalLabReview
+Authorization: Bearer {{placer_token}}
+HTTP 403

--- a/tests/hurl/11-task-requester-gate.hurl
+++ b/tests/hurl/11-task-requester-gate.hurl
@@ -34,8 +34,8 @@ GET {{hapi_url}}/fhir/fulfiller/Task
 HTTP 200
 [Asserts]
 jsonpath "$.resourceType" == "Bundle"
-jsonpath "$.entry[*].resource.id" contains "TaskOrthopedicReferral"
-jsonpath "$.entry[*].resource.id" contains "TaskInternalLabReview"
+jsonpath "$.entry[*].resource.id" includes "TaskOrthopedicReferral"
+jsonpath "$.entry[*].resource.id" includes "TaskInternalLabReview"
 
 
 # --- 2. Placer searches Task list at Fulfiller's external gateway ---
@@ -53,8 +53,8 @@ Authorization: Bearer {{placer_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.resourceType" == "Bundle"
-jsonpath "$.entry[*].resource.id" contains "TaskOrthopedicReferral"
-jsonpath "$.entry[*].resource.id" not contains "TaskInternalLabReview"
+jsonpath "$.entry[*].resource.id" includes "TaskOrthopedicReferral"
+jsonpath "$.entry[*].resource.id" not includes "TaskInternalLabReview"
 
 
 # --- 3. Placer reads that Task by id (Task.requester matches → allow) ---

--- a/tests/scripts/get-token.sh
+++ b/tests/scripts/get-token.sh
@@ -103,7 +103,10 @@ fetch_l2_token() {
 
     body="grant_type=client_credentials&client_id=${l2_cid}"
     body="${body}&client_assertion_type=${CLIENT_ASSERTION_TYPE}&client_assertion=${assertion}"
-    body="${body}&scope=$(echo "$l2_scope" | sed 's/ /+/g')"
+    # Skip scope param when empty so Keycloak applies the client's defaults
+    # only. M2M flows don't take `openid` — the access token's `system/*`
+    # scopes come from defaultClientScopes regardless.
+    [ -n "$l2_scope" ] && body="${body}&scope=$(echo "$l2_scope" | sed 's/ /+/g')"
     [ -n "$auth_details" ] && body="${body}&authorization_details=$(url_encode "$auth_details")"
 
     fetch_token "$body"
@@ -111,39 +114,34 @@ fetch_l2_token() {
 
 case "$CLIENT_TYPE" in
   placer)
-    SCOPE="smart-task-write smart-servicerequest-read smart-clinical-read smart-questionnaire-write"
-    fetch_token "grant_type=client_credentials&client_id=placer-client&client_secret=placer-secret-2025&scope=$(echo "$SCOPE" | sed 's/ /+/g')"
+    fetch_token "grant_type=client_credentials&client_id=placer-client&client_secret=placer-secret-2025"
     ;;
   fulfiller)
-    SCOPE="smart-task-write smart-servicerequest-read smart-clinical-read smart-patient-read smart-questionnaire-write"
-    fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025&scope=$(echo "$SCOPE" | sed 's/ /+/g')"
+    fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025"
     ;;
   fulfiller-context)
     # RFC 9396 authorization_details token for cross-party reads
     SR="${SR_ID:-ReferralOrthopedicSurgery}"
-    SCOPE="smart-task-write smart-servicerequest-read smart-clinical-read smart-patient-read"
     AUTH_DETAILS='[{"type":"umzh-connect-context","identifier":"ServiceRequest/'"$SR"'"}]'
     AUTH_DETAILS_ENC=$(url_encode "$AUTH_DETAILS")
-    fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025&scope=$(echo "$SCOPE" | sed 's/ /+/g')&authorization_details=${AUTH_DETAILS_ENC}"
+    fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025&authorization_details=${AUTH_DETAILS_ENC}"
     ;;
   placer-user)
-    fetch_token "grant_type=password&client_id=web-app&username=placer-user&password=placer123&scope=openid+smart-patient-read+smart-task-write+smart-servicerequest-read+smart-clinical-read"
+    # User flow — openid IS appropriate here (authenticates a user; an ID token is meaningful)
+    fetch_token "grant_type=password&client_id=web-app&username=placer-user&password=placer123&scope=openid"
     ;;
   fulfiller-user)
-    fetch_token "grant_type=password&client_id=web-app&username=fulfiller-user&password=fulfiller123&scope=openid+smart-patient-read+smart-task-write+smart-servicerequest-read+smart-clinical-read"
+    fetch_token "grant_type=password&client_id=web-app&username=fulfiller-user&password=fulfiller123&scope=openid"
     ;;
   placer-l2)
-    fetch_l2_token placer-client-l2 placer-l2 \
-      "smart-task-write smart-servicerequest-read smart-clinical-read smart-questionnaire-write"
+    fetch_l2_token placer-client-l2 placer-l2 ""
     ;;
   fulfiller-l2)
-    fetch_l2_token fulfiller-client-l2 fulfiller-l2 \
-      "smart-task-write smart-servicerequest-read smart-clinical-read smart-patient-read smart-questionnaire-write"
+    fetch_l2_token fulfiller-client-l2 fulfiller-l2 ""
     ;;
   fulfiller-l2-context)
     SR="${SR_ID:-ReferralOrthopedicSurgery}"
-    fetch_l2_token fulfiller-client-l2 fulfiller-l2 \
-      "smart-task-write smart-servicerequest-read smart-clinical-read smart-patient-read" \
+    fetch_l2_token fulfiller-client-l2 fulfiller-l2 "" \
       '[{"type":"umzh-connect-context","identifier":"ServiceRequest/'"$SR"'"}]'
     ;;
   *)

--- a/web-app/src/pages/CredentialsPage.tsx
+++ b/web-app/src/pages/CredentialsPage.tsx
@@ -113,11 +113,13 @@ const CredentialsPage: React.FC = () => {
       let data: Record<string, unknown>;
 
       if (activeLevel === 'l1') {
+        // M2M flow — no `openid` scope. There's no user to attest to and no
+        // meaningful ID token in client_credentials. The token's system/*
+        // scopes come from the client's defaultClientScopes in Keycloak.
         const body = new URLSearchParams({
           grant_type:    'client_credentials',
           client_id:     cfg.l1.clientId,
           client_secret: cfg.l1.clientSecret,
-          scope:         'openid',
         });
         if (ref) body.set('authorization_details',
           JSON.stringify([{ type: 'umzh-connect-context', identifier: ref }]));
@@ -151,12 +153,12 @@ const CredentialsPage: React.FC = () => {
         const assertion = await buildClientAssertion(cfg.l2.clientId, KEYCLOAK_TOKEN_URL, cryptoKey, cfg.l2.kid);
         setAssertionData(assertion);
 
+        // Same as L1: M2M, no `openid` scope.
         const body = new URLSearchParams({
           grant_type:            'client_credentials',
           client_id:             cfg.l2.clientId,
           client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
           client_assertion:      assertion.jwt,
-          scope:                 'openid',
         });
         if (ref) body.set('authorization_details',
           JSON.stringify([{ type: 'umzh-connect-context', identifier: ref }]));


### PR DESCRIPTION
Two related cleanups in one commit:
  1. smart-* aliases and the openid scope were decorative for M2M — OPA only ever read system/*, and openid has no meaning in client_credentials
  2. the /Task surface at external gateways had no scope or per-caller gating, so any valid token could list or read any Task

Scope cleanup:
- Drop 5 smart-* client scopes from the realm and every client reference.
- Drop scope=openid from all M2M flows (hurl, get-token.sh, CredentialsPage). Keep it on user password grants.
- Add a sample system/Patient.r assertion in 02-auth.

Task gate:
- Rename system/Task.cru -> system/Task.crus (SMART v2 .s for search).
- ext-task-list route now runs opa + a new umzh-task-requester-inject plugin that appends ?requester=<token.org_ref> to the upstream URL via ctx.var.upstream_uri. Caller cannot override the filter.
- OPA Rule 1 split into 1a (search: require .s), 1b (read by id: require .r AND fetched Task.requester == token.org_ref), 1c (writes unchanged). New fetched_task helper.
- Seed Task.requester rewritten to Organization/HospitalP; new seed Task TaskInternalLabReview (requester=HospitalF) gives the filter something to actually exclude.

Tests: 11/11 pass under both L1 and L2. New 11-task-requester-gate covers the partition baseline, search filter, allow on match, deny on mismatch.