### PR TITLE
Fix Task.requester to reference the registry Organization (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,17 @@ docker compose up -d --build
 # The seed-loader runs once on first start and populates FHIR data.
 ```
 
+### Open the App
+
+1. Open http://localhost:3000
+2. Log in as `placer-user` / `placer123` (see [Default Credentials](#default-credentials) below)
+3. You start in the **Placer** role — the patient list shows
+   PetraMeier and her referrals. Switch role (Placer/Fulfiller/Registry)
+   from the header.
+
+The app requires login (Keycloak PKCE) — without it the patient list is
+empty even though the FHIR data is loaded.
+
 ### Verify Services
 
 | Service | URL | Check |

--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -1,0 +1,3 @@
+
+# Dev-only: Vite serves the L2 demo keys (nginx does this in Docker)
+public/l2-keys

--- a/web-app/src/components/fhir/CreateTaskModal.tsx
+++ b/web-app/src/components/fhir/CreateTaskModal.tsx
@@ -23,7 +23,7 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({
   defaultSRId,
   onSuccessResource,
 }) => {
-  const { activeRole, apiBasePath, partnerExternalBaseUrl, ownExternalBaseUrl, registryBaseUrl, ownL2ClientId } = useRole();
+  const { activeRole, apiBasePath, partnerExternalBaseUrl, ownExternalBaseUrl, registryBaseUrl, ownOrgRegistryRef, ownL2ClientId } = useRole();
   const { addLog } = useLog();
   const getPartnerClient = usePartnerClient();
   const queryClient = useQueryClient();
@@ -112,9 +112,13 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({
       }),
       for: { reference: `${ownExternalBaseUrl}/${patientRef}`, display: patientDisplay },
       authoredOn: new Date().toISOString(),
+      // The IG profile (ch-umzh-connect-coordinationtask) constrains
+      // Task.requester to Reference(Organization) with an absolute URL, and the
+      // partner's external gateway filters Task searches by this organization
+      // reference — so it must be THIS party's registry Organization, not a
+      // PractitionerRole. See issue #24.
       requester: {
-        reference: `${ownExternalBaseUrl}/PractitionerRole/HansMusterRole`,
-        display: 'Dr. med. Hans Muster',
+        reference: ownOrgRegistryRef,
       },
       ...(partnerOrgRegistryRef && {
         owner: {

--- a/web-app/src/contexts/RoleContext.tsx
+++ b/web-app/src/contexts/RoleContext.tsx
@@ -34,6 +34,13 @@ interface RoleContextType {
   ownExternalBaseUrl: string;
   /** Base URL for the Organization registry (public, no auth), e.g. http://localhost:8084/fhir */
   registryBaseUrl: string;
+  /**
+   * Absolute registry reference to THIS party's own Organization, e.g.
+   * http://localhost:8084/fhir/Organization/HospitalP. Used as Task.requester,
+   * which the IG profile constrains to Reference(Organization) with an absolute
+   * URL (ch-umzh-connect-coordinationtask). Empty for the registry role.
+   */
+  ownOrgRegistryRef: string;
   // ─── L2 identity for in-browser client_credentials (cross-party calls) ───
   /** Keycloak token endpoint used for the M2M exchange. */
   keycloakTokenUrl: string;
@@ -55,6 +62,7 @@ const RoleContext = createContext<RoleContextType>({
   partnerExternalBaseUrl: `${FULFILLER_EXTERNAL_URL}/fhir`,
   ownExternalBaseUrl: `${PLACER_EXTERNAL_URL}/fhir`,
   registryBaseUrl: `${REGISTRY_URL}/fhir`,
+  ownOrgRegistryRef: `${REGISTRY_URL}/fhir/Organization/HospitalP`,
   keycloakTokenUrl: KEYCLOAK_TOKEN_URL,
   ownL2ClientId: 'placer-client-l2',
   ownL2Kid: 'placer-l2',
@@ -86,6 +94,7 @@ export const RoleProvider: React.FC<{ children: React.ReactNode }> = ({ children
         partnerExternalBaseUrl:  `${FULFILLER_EXTERNAL_URL}/fhir`,
         ownExternalBaseUrl:      `${PLACER_EXTERNAL_URL}/fhir`,
         registryBaseUrl,
+        ownOrgRegistryRef:       `${registryBaseUrl}/Organization/HospitalP`,
         keycloakTokenUrl:        KEYCLOAK_TOKEN_URL,
         ownL2ClientId:           'placer-client-l2',
         ownL2Kid:                'placer-l2',
@@ -99,6 +108,7 @@ export const RoleProvider: React.FC<{ children: React.ReactNode }> = ({ children
         partnerExternalBaseUrl:  `${PLACER_EXTERNAL_URL}/fhir`,
         ownExternalBaseUrl:      `${FULFILLER_EXTERNAL_URL}/fhir`,
         registryBaseUrl,
+        ownOrgRegistryRef:       `${registryBaseUrl}/Organization/HospitalF`,
         keycloakTokenUrl:        KEYCLOAK_TOKEN_URL,
         ownL2ClientId:           'fulfiller-client-l2',
         ownL2Kid:                'fulfiller-l2',
@@ -111,6 +121,7 @@ export const RoleProvider: React.FC<{ children: React.ReactNode }> = ({ children
         partnerExternalBaseUrl:  '',
         ownExternalBaseUrl:      registryBaseUrl,
         registryBaseUrl,
+        ownOrgRegistryRef:       '',
         keycloakTokenUrl:        KEYCLOAK_TOKEN_URL,
         ownL2ClientId:           '',
         ownL2Kid:                '',


### PR DESCRIPTION
Closes #24.

## Problem

Tasks created through the web-app set `Task.requester` to a **PractitionerRole** reference (`.../PractitionerRole/HansMusterRole`). This:

1. **Violates the IG profile** `ch-umzh-connect-coordinationtask`, which constrains `requester` to `1..1 Reference(Organization)` with an absolute URL.
2. **Hides the Task from the partner.** The Fulfiller external gateway's `umzh-task-requester-inject` plugin forces `requester=<caller org reference>` onto every Task search (from the JWT claim `extensions.umzhconnect.organization_reference` = `Organization/HospitalP`). A Task whose requester is a PractitionerRole never matches, so the Placer never sees it — regardless of status (e.g. a Fulfiller-completed Task stayed invisible).

## Fix

- Add `ownOrgRegistryRef` to `RoleContext` — the party's own registry Organization URL (`${registryBaseUrl}/Organization/HospitalP` for placer, `.../HospitalF` for fulfiller; empty for registry).
- Use it for `Task.requester` in `CreateTaskModal` instead of the PractitionerRole reference.

This aligns the UI with the convention already used by the seed data (`fulfiller-bundle.json`) and the `06-workflow` / `11-task-requester-gate` Hurl tests, all of which already use `Organization` requesters. The UI was the sole outlier.

## Scope notes

- `TaskOrthopedicReferral` seed data was already correct (`Organization/HospitalP`) — no change.
- `ServiceRequest.requester` (e.g. WorkflowWizard, placer-bundle) is intentionally left as `PractitionerRole` — the ServiceRequest profile does not constrain it.

## Testing

- `npx tsc --noEmit` passes.
- Verified manually via the Vite dev server: created a Task as Placer, confirmed `requester = .../Organization/HospitalP` in the fulfiller partition, set it `completed` as Fulfiller, and confirmed it now appears in the Placer's Task list.
- The server-side contract is covered by `tests/hurl/11-task-requester-gate.hurl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also included

- **docs:** add an explicit "Open the App" / login step to the Quick Start. Without logging in, the patient list is empty even though data is seeded — the login requirement was only implied before.
- **chore:** `.gitignore` the dev-only `public/l2-keys` symlink. The web-app's nginx serves the L2 demo keys at `/l2-keys/` in Docker, but the Vite dev server has no such route; symlinking `services/keys` into `public/l2-keys` lets the dev server serve them (otherwise in-browser `private_key_jwt` signing fails with an `atob` decode error). The symlink stays local.
