### PR TITLE
build(web-app): .dockerignore to fix vite build in Docker

### DIFF
--- a/web-app/.dockerignore
+++ b/web-app/.dockerignore
@@ -1,0 +1,15 @@
+# Dev-only symlink (-> ../../services/keys) used by `npm run dev` to serve
+# /l2-keys/ locally. It dangles inside the Docker build context and breaks
+# `vite build` (it copies public/ to dist). At runtime the image serves
+# /l2-keys/ from the compose bind-mount instead, so it is not needed here.
+public/l2-keys
+
+# Host build artifacts — re-created inside the image; copying the macOS
+# node_modules over the freshly `npm install`ed one can break native binaries
+# (esbuild/rollup) and bloats the context.
+node_modules
+dist
+
+# Misc
+.git
+*.log


### PR DESCRIPTION
## Problem
The dev-only `web-app/public/l2-keys` symlink (`-> ../../services/keys`, git-ignored) is pulled into the Docker build context by `COPY . .` and dangles there. `vite build` copies `public/` to `dist/` and fails:

```
ENOENT: no such file or directory, stat '/app/public/l2-keys'
```

This breaks `docker compose build web-app` for anyone who has the dev symlink locally.

## Fix
Add `web-app/.dockerignore` excluding `public/l2-keys` (the image serves `/l2-keys/` from the compose bind-mount at runtime, so it isn't needed in the build context) plus `node_modules`/`dist`.

Standalone, single-file change — applies cleanly on its own and independently of the runtime-config work in #19.

Verified: `docker compose build web-app` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)