### PR TITLE
Add RFC 8707 resource indicators for cross-party token audience

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.6.1
     container_name: umzh-keycloak
-    command: start-dev --import-realm
+    command: start-dev --import-realm --features=resource-indicators
     environment:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
@@ -69,6 +69,9 @@ services:
       # Internal Docker address by default; public partner subdomains in prod.
       PLACER_JWKS_URL: ${PLACER_JWKS_URL:-http://apisix-placer-external:9080/jwks.json}
       FULFILLER_JWKS_URL: ${FULFILLER_JWKS_URL:-http://apisix-fulfiller-external:9080/jwks.json}
+      # RFC 8707 resource_url attribute on the gateway resource-server clients.
+      PLACER_EXTERNAL_URL: ${VITE_PLACER_EXTERNAL_URL:-http://localhost:8081}
+      FULFILLER_EXTERNAL_URL: ${VITE_FULFILLER_EXTERNAL_URL:-http://localhost:8083}
       KC_HEALTH_ENABLED: 'true'
       KC_HTTP_PORT: 8080
       KC_HOSTNAME: 'http://localhost:8180'

--- a/services/keycloak/realm-export.json
+++ b/services/keycloak/realm-export.json
@@ -297,8 +297,21 @@
             "access.token.claim": "true",
             "userinfo.token.claim": "false"
           }
+        },
+        {
+          "name": "audience-fulfiller-external",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "fulfiller-external-gateway",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
-      ]
+      ],
+      "attributes": {
+        "client_credentials.use_refresh_token": "true"
+      }
     },
     {
       "clientId": "fulfiller-client",
@@ -384,8 +397,21 @@
             "access.token.claim": "true",
             "userinfo.token.claim": "false"
           }
+        },
+        {
+          "name": "audience-placer-external",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "placer-external-gateway",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
-      ]
+      ],
+      "attributes": {
+        "client_credentials.use_refresh_token": "true"
+      }
     },
     {
       "clientId": "placer-client-l2",
@@ -399,7 +425,8 @@
       "clientAuthenticatorType": "client-jwt",
       "attributes": {
         "use.jwks.url": "true",
-        "jwks.url": "${PLACER_JWKS_URL:http://apisix-placer-external:9080/jwks.json}"
+        "jwks.url": "${PLACER_JWKS_URL:http://apisix-placer-external:9080/jwks.json}",
+        "client_credentials.use_refresh_token": "true"
       },
       "protocol": "openid-connect",
       "webOrigins": [
@@ -472,6 +499,16 @@
             "access.token.claim": "true",
             "userinfo.token.claim": "false"
           }
+        },
+        {
+          "name": "audience-fulfiller-external",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "fulfiller-external-gateway",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
       ]
     },
@@ -487,7 +524,8 @@
       "clientAuthenticatorType": "client-jwt",
       "attributes": {
         "use.jwks.url": "true",
-        "jwks.url": "${FULFILLER_JWKS_URL:http://apisix-fulfiller-external:9080/jwks.json}"
+        "jwks.url": "${FULFILLER_JWKS_URL:http://apisix-fulfiller-external:9080/jwks.json}",
+        "client_credentials.use_refresh_token": "true"
       },
       "protocol": "openid-connect",
       "webOrigins": [
@@ -562,8 +600,44 @@
             "access.token.claim": "true",
             "userinfo.token.claim": "false"
           }
+        },
+        {
+          "name": "audience-placer-external",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "placer-external-gateway",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
       ]
+    },
+    {
+      "clientId": "placer-external-gateway",
+      "name": "Placer External Gateway (Resource Server)",
+      "description": "RFC 8707 resource-server registration for the placer external APISIX gateway",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "resource_url": "${PLACER_EXTERNAL_URL:http://localhost:8081}"
+      }
+    },
+    {
+      "clientId": "fulfiller-external-gateway",
+      "name": "Fulfiller External Gateway (Resource Server)",
+      "description": "RFC 8707 resource-server registration for the fulfiller external APISIX gateway",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "resource_url": "${FULFILLER_EXTERNAL_URL:http://localhost:8083}"
+      }
     }
   ],
   "users": [

--- a/tests/Dockerfile.test-runner
+++ b/tests/Dockerfile.test-runner
@@ -3,9 +3,6 @@
 # and openssl to sign the assertion — add both.
 FROM ghcr.io/orange-opensource/hurl:6.0.0
 USER root
-# Set APK_INSECURE=1 (build arg) to fetch packages over the http mirror — a
-# local escape hatch for networks with a TLS-intercepting proxy. Unset in CI,
-# so the default https mirror is used.
-ARG APK_INSECURE=
-RUN if [ -n "$APK_INSECURE" ]; then sed -i 's|https://|http://|g' /etc/apk/repositories; fi \
+ARG BUILD_INSECURE=
+RUN if [ -n "$BUILD_INSECURE" ]; then sed -i 's|https://|http://|g' /etc/apk/repositories; fi \
  && apk add --no-cache curl openssl

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -26,6 +26,10 @@ services:
       APISIX_PLACER_EXT_URL: http://apisix-placer-external:9080
       APISIX_FULFILLER_URL: http://apisix-fulfiller-internal:9080
       APISIX_FULFILLER_EXT_URL: http://apisix-fulfiller-external:9080
+      # RFC 8707 resource URIs — must match Keycloak's registered resource_url
+      # (PLACER_EXTERNAL_URL / FULFILLER_EXTERNAL_URL in docker-compose.yml).
+      PLACER_RESOURCE_URL: ${VITE_PLACER_EXTERNAL_URL:-http://localhost:8081}
+      FULFILLER_RESOURCE_URL: ${VITE_FULFILLER_EXTERNAL_URL:-http://localhost:8083}
       HAPI_FHIR_URL: http://hapi-fhir:8080
       REGISTRY_URL: http://nginx-proxy:84
       ORG_CANONICAL_URL: ${VITE_REGISTRY_URL:-http://localhost:8084}

--- a/tests/hurl/12-resource-indicators.hurl
+++ b/tests/hurl/12-resource-indicators.hurl
@@ -1,0 +1,57 @@
+# =============================================================================
+# 12-resource-indicators.hurl — RFC 8707 Resource Indicator Tests
+#
+# Verifies that Keycloak's resource-indicators experimental feature behaves
+# correctly: a valid resource URI restricts the token audience, and an unknown
+# resource URI is rejected with invalid_target.
+# =============================================================================
+
+
+# --- Positive: valid resource URI → token issued ---
+# placer-client requests a token scoped to the fulfiller external gateway.
+# Expects 200 with an access_token.
+
+POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+[FormParams]
+grant_type: client_credentials
+client_id: placer-client
+client_secret: placer-secret-2025
+resource: {{fulfiller_resource_url}}
+HTTP 200
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.token_type" == "Bearer"
+
+
+# --- Negative: unknown resource URI → invalid_target ---
+# A resource URI that matches no registered Keycloak client resource_url
+# must be rejected per RFC 8707 §2.
+
+POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+[FormParams]
+grant_type: client_credentials
+client_id: placer-client
+client_secret: placer-secret-2025
+resource: http://not-a-registered-gateway
+HTTP 400
+[Asserts]
+jsonpath "$.error" == "invalid_target"
+
+
+# --- Negative: registered resource URI but client not authorised for it ---
+# placer-client has no audience mapper for placer-external-gateway (its own
+# external gateway). The resource URI is registered in Keycloak but not in
+# this client's audience — the post-processor must still reject it.
+
+POST {{keycloak_url}}/realms/umzh-connect/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+[FormParams]
+grant_type: client_credentials
+client_id: placer-client
+client_secret: placer-secret-2025
+resource: {{placer_resource_url}}
+HTTP 400
+[Asserts]
+jsonpath "$.error" == "invalid_target"

--- a/tests/scripts/get-token.sh
+++ b/tests/scripts/get-token.sh
@@ -19,6 +19,7 @@
 KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:8180}"
 TOKEN_URL="${KEYCLOAK_URL}/realms/umzh-connect/protocol/openid-connect/token"
 
+
 # The L2 client assertion's `aud` must be Keycloak's *published* (frontend)
 # token endpoint — the URL it advertises under KC_HOSTNAME and validates the
 # assertion against. In CI we POST to the internal backchannel (keycloak:8080)
@@ -32,6 +33,14 @@ TOKEN_AUD="${TOKEN_AUD:-${KEYCLOAK_ISSUER}/protocol/openid-connect/token}"
 # ports; in CI (test-runner inside Docker) they're reachable by container name.
 KEY_CUSTODIAN_PLACER_URL="${KEY_CUSTODIAN_PLACER_URL:-http://localhost:8087}"
 KEY_CUSTODIAN_FULFILLER_URL="${KEY_CUSTODIAN_FULFILLER_URL:-http://localhost:8089}"
+
+# RFC 8707 resource URIs sent to Keycloak — must exactly match the resource_url
+# registered on each gateway's resource-server client (PLACER_EXTERNAL_URL /
+# FULFILLER_EXTERNAL_URL in docker-compose.yml). In CI these differ from the
+# Docker-internal APISIX URLs above, so they are configured separately.
+PLACER_RESOURCE_URL="${PLACER_RESOURCE_URL:-http://localhost:8081}"
+FULFILLER_RESOURCE_URL="${FULFILLER_RESOURCE_URL:-http://localhost:8083}"
+
 CLIENT_ASSERTION_TYPE="urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"
 
 CLIENT_TYPE="$1"
@@ -64,11 +73,12 @@ url_encode() {
 #   $2 = custodian base URL  e.g. http://localhost:8087
 #   $3 = space-separated scope (may be empty)
 #   $4 = optional authorization_details JSON
+#   $5 = optional RFC 8707 resource URI  e.g. http://localhost:8083
 #
 # The custodian sets iss/sub/kid from its own env, so we only need to supply
 # the audience.
 fetch_l2_token() {
-    l2_cid="$1"; custodian_url="$2"; l2_scope="$3"; auth_details="$4"
+    l2_cid="$1"; custodian_url="$2"; l2_scope="$3"; auth_details="$4"; resource="$5"
 
     sign_resp=$(curl -sf -X POST \
         -H "Content-Type: application/json" \
@@ -91,6 +101,7 @@ fetch_l2_token() {
     # scopes come from defaultClientScopes regardless.
     [ -n "$l2_scope" ] && body="${body}&scope=$(echo "$l2_scope" | sed 's/ /+/g')"
     [ -n "$auth_details" ] && body="${body}&authorization_details=$(url_encode "$auth_details")"
+    [ -n "$resource" ] && body="${body}&resource=$(url_encode "$resource")"
 
     fetch_token "$body"
 }
@@ -103,11 +114,12 @@ case "$CLIENT_TYPE" in
     fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025"
     ;;
   fulfiller-context)
-    # RFC 9396 authorization_details token for cross-party reads
+    # RFC 9396 authorization_details token for cross-party reads (fulfiller → placer external)
     SR="${SR_ID:-ReferralOrthopedicSurgery}"
     AUTH_DETAILS='[{"type":"umzh-connect-context","identifier":"ServiceRequest/'"$SR"'"}]'
     AUTH_DETAILS_ENC=$(url_encode "$AUTH_DETAILS")
-    fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025&authorization_details=${AUTH_DETAILS_ENC}"
+    RESOURCE_ENC=$(url_encode "$PLACER_RESOURCE_URL")
+    fetch_token "grant_type=client_credentials&client_id=fulfiller-client&client_secret=fulfiller-secret-2025&authorization_details=${AUTH_DETAILS_ENC}&resource=${RESOURCE_ENC}"
     ;;
   placer-context)
     # RFC 9396 authorization_details token — placer reading Task output resources
@@ -115,7 +127,8 @@ case "$CLIENT_TYPE" in
     TASK="${SR_ID:-TaskOrthopedicReferral}"
     AUTH_DETAILS='[{"type":"umzh-connect-context","identifier":"Task/'"$TASK"'"}]'
     AUTH_DETAILS_ENC=$(url_encode "$AUTH_DETAILS")
-    fetch_token "grant_type=client_credentials&client_id=placer-client&client_secret=placer-secret-2025&authorization_details=${AUTH_DETAILS_ENC}"
+    RESOURCE_ENC=$(url_encode "$FULFILLER_RESOURCE_URL")
+    fetch_token "grant_type=client_credentials&client_id=placer-client&client_secret=placer-secret-2025&authorization_details=${AUTH_DETAILS_ENC}&resource=${RESOURCE_ENC}"
     ;;
   placer-user)
     # User flow — openid IS appropriate here (authenticates a user; an ID token is meaningful)
@@ -125,20 +138,24 @@ case "$CLIENT_TYPE" in
     fetch_token "grant_type=password&client_id=web-app&username=fulfiller-user&password=fulfiller123&scope=openid"
     ;;
   placer-l2)
-    fetch_l2_token placer-client-l2 "$KEY_CUSTODIAN_PLACER_URL" ""
+    fetch_l2_token placer-client-l2 "$KEY_CUSTODIAN_PLACER_URL" "" "" \
+      "$FULFILLER_RESOURCE_URL"
     ;;
   fulfiller-l2)
-    fetch_l2_token fulfiller-client-l2 "$KEY_CUSTODIAN_FULFILLER_URL" ""
+    fetch_l2_token fulfiller-client-l2 "$KEY_CUSTODIAN_FULFILLER_URL" "" "" \
+      "$PLACER_RESOURCE_URL"
     ;;
   fulfiller-l2-context)
     SR="${SR_ID:-ReferralOrthopedicSurgery}"
     fetch_l2_token fulfiller-client-l2 "$KEY_CUSTODIAN_FULFILLER_URL" "" \
-      '[{"type":"umzh-connect-context","identifier":"ServiceRequest/'"$SR"'"}]'
+      '[{"type":"umzh-connect-context","identifier":"ServiceRequest/'"$SR"'"}]' \
+      "$PLACER_RESOURCE_URL"
     ;;
   placer-l2-context)
     TASK="${SR_ID:-TaskOrthopedicReferral}"
     fetch_l2_token placer-client-l2 "$KEY_CUSTODIAN_PLACER_URL" "" \
-      '[{"type":"umzh-connect-context","identifier":"Task/'"$TASK"'"}]'
+      '[{"type":"umzh-connect-context","identifier":"Task/'"$TASK"'"}]' \
+      "$FULFILLER_RESOURCE_URL"
     ;;
   *)
     echo "Usage: get-token.sh <placer|fulfiller|fulfiller-context|placer-context|placer-user|fulfiller-user|placer-l2|fulfiller-l2|fulfiller-l2-context|placer-l2-context> [resource_id]" >&2

--- a/tests/scripts/run-tests.sh
+++ b/tests/scripts/run-tests.sh
@@ -110,6 +110,10 @@ APISIX_PLACER_URL="${APISIX_PLACER_URL:-http://localhost:8080}"
 APISIX_PLACER_EXT_URL="${APISIX_PLACER_EXT_URL:-http://localhost:8081}"
 APISIX_FULFILLER_URL="${APISIX_FULFILLER_URL:-http://localhost:8082}"
 APISIX_FULFILLER_EXT_URL="${APISIX_FULFILLER_EXT_URL:-http://localhost:8083}"
+# RFC 8707 resource URIs — must match Keycloak's registered resource_url values.
+# In CI these differ from APISIX_*_EXT_URL (Docker-internal vs public-facing).
+PLACER_RESOURCE_URL="${PLACER_RESOURCE_URL:-http://localhost:8081}"
+FULFILLER_RESOURCE_URL="${FULFILLER_RESOURCE_URL:-http://localhost:8083}"
 HAPI_FHIR_URL="${HAPI_FHIR_URL:-http://localhost:8090}"
 REGISTRY_URL="${REGISTRY_URL:-http://localhost:8084}"
 # Canonical URL for Organization FHIR references — matches seed data and KC token claim.
@@ -149,6 +153,8 @@ for hurl_file in "$HURL_DIR"/[0-9]*.hurl; do
         --variable "placer_ext_url=$APISIX_PLACER_EXT_URL" \
         --variable "fulfiller_url=$APISIX_FULFILLER_URL" \
         --variable "fulfiller_ext_url=$APISIX_FULFILLER_EXT_URL" \
+        --variable "placer_resource_url=$PLACER_RESOURCE_URL" \
+        --variable "fulfiller_resource_url=$FULFILLER_RESOURCE_URL" \
         --variable "hapi_url=$HAPI_FHIR_URL" \
         --variable "registry_url=$REGISTRY_URL" \
         --variable "org_url=$ORG_CANONICAL_URL" \

--- a/web-app/src/hooks/useFhirClient.ts
+++ b/web-app/src/hooks/useFhirClient.ts
@@ -45,8 +45,14 @@ export function useRegistryClient(): FhirClient {
  * partner external gateway directly.
  */
 export function useM2mToken(): (fhirContextRef?: string) => Promise<string> {
-  const { keycloakTokenUrl, ownL2ClientId, ownL2Kid, ownL2KeyUrl } = useRole();
+  const { keycloakTokenUrl, ownL2ClientId, ownL2Kid, ownL2KeyUrl,
+          partnerExternalBaseUrl } = useRole();
   const { addLog } = useLog();
+
+  // Strip /fhir suffix to get the gateway base URL used as RFC 8707 resource indicator.
+  const partnerResource = partnerExternalBaseUrl
+    ? partnerExternalBaseUrl.replace(/\/fhir$/, '')
+    : undefined;
 
   return useCallback(
     (fhirContextRef?: string) =>
@@ -56,9 +62,10 @@ export function useM2mToken(): (fhirContextRef?: string) => Promise<string> {
         kid: ownL2Kid,
         keyUrl: ownL2KeyUrl,
         fhirContextRef,
+        resource: partnerResource,
         onLog: addLog,
       }),
-    [keycloakTokenUrl, ownL2ClientId, ownL2Kid, ownL2KeyUrl, addLog]
+    [keycloakTokenUrl, ownL2ClientId, ownL2Kid, ownL2KeyUrl, partnerResource, addLog]
   );
 }
 

--- a/web-app/src/pages/CredentialsPage.tsx
+++ b/web-app/src/pages/CredentialsPage.tsx
@@ -3,24 +3,33 @@ import JsonViewer from '../components/common/JsonViewer';
 import { useLog } from '../contexts/LogContext';
 import { importPrivateKey, buildClientAssertion } from '../services/l2-signing';
 import type { AssertionParts } from '../services/l2-signing';
+import {
+  VITE_KEYCLOAK_URL        as KEYCLOAK_URL,
+  VITE_KEYCLOAK_REALM      as KEYCLOAK_REALM,
+  VITE_PLACER_EXTERNAL_URL as PLACER_EXTERNAL_URL,
+  VITE_FULFILLER_EXTERNAL_URL as FULFILLER_EXTERNAL_URL,
+  VITE_REGISTRY_URL        as REGISTRY_URL,
+} from '../config/env';
 
 type Party = 'placer' | 'fulfiller';
 type Level = 'l1' | 'l2';
 
 const KEYCLOAK_TOKEN_URL =
-  'http://localhost:8180/realms/umzh-connect/protocol/openid-connect/token';
+  `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
 
 const CLIENT_CONFIG = {
   placer: {
     l1: { clientId: 'placer-client', clientSecret: 'placer-secret-2025' },
     l2: { clientId: 'placer-client-l2', keyUrl: '/l2-keys/placer-l2.key', kid: 'placer-l2' },
-    orgReference: 'http://localhost:8084/fhir/Organization/HospitalP',
+    partnerExternalUrl: FULFILLER_EXTERNAL_URL,
+    orgReference: `${REGISTRY_URL}/fhir/Organization/HospitalP`,
     label: 'HospitalP (Placer)',
   },
   fulfiller: {
     l1: { clientId: 'fulfiller-client', clientSecret: 'fulfiller-secret-2025' },
     l2: { clientId: 'fulfiller-client-l2', keyUrl: '/l2-keys/fulfiller-l2.key', kid: 'fulfiller-l2' },
-    orgReference: 'http://localhost:8084/fhir/Organization/HospitalF',
+    partnerExternalUrl: PLACER_EXTERNAL_URL,
+    orgReference: `${REGISTRY_URL}/fhir/Organization/HospitalF`,
     label: 'HospitalF (Fulfiller)',
   },
 } as const;
@@ -35,16 +44,23 @@ const CredentialsPage: React.FC = () => {
   const [activeParty, setActiveParty]       = useState<Party>('placer');
   const [activeLevel, setActiveLevel]       = useState<Level>('l1');
   const [contextRef, setContextRef]         = useState('');
+  const [resourceUri, setResourceUri]       = useState<string>(CLIENT_CONFIG.placer.partnerExternalUrl);
 
-  // Reset assertion inspector when switching party or level
-  const switchParty = (p: Party) => { setActiveParty(p); setAssertionData(null); setTokenResponse(null); };
+  // Reset assertion inspector when switching party or level; update resource default.
+  const switchParty = (p: Party) => {
+    setActiveParty(p);
+    setAssertionData(null);
+    setTokenResponse(null);
+    setResourceUri(CLIENT_CONFIG[p].partnerExternalUrl);
+  };
   const switchLevel = (l: Level) => { setActiveLevel(l); setAssertionData(null); setTokenResponse(null); };
 
   const handleRequestToken = async () => {
     setLoading(true);
     setAssertionData(null);
-    const cfg = CLIENT_CONFIG[activeParty];
-    const ref = contextRef.trim();
+    const cfg      = CLIENT_CONFIG[activeParty];
+    const ref      = contextRef.trim();
+    const resource = resourceUri.trim();
 
     try {
       let data: Record<string, unknown>;
@@ -60,6 +76,7 @@ const CredentialsPage: React.FC = () => {
         });
         if (ref) body.set('authorization_details',
           JSON.stringify([{ type: 'umzh-connect-context', identifier: ref }]));
+        if (resource) body.set('resource', resource);
 
         addLog({ type: 'request', method: 'POST', url: KEYCLOAK_TOKEN_URL,
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -99,6 +116,7 @@ const CredentialsPage: React.FC = () => {
         });
         if (ref) body.set('authorization_details',
           JSON.stringify([{ type: 'umzh-connect-context', identifier: ref }]));
+        if (resource) body.set('resource', resource);
 
         addLog({ type: 'request', method: 'POST', url: KEYCLOAK_TOKEN_URL,
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -108,6 +126,7 @@ const CredentialsPage: React.FC = () => {
             client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
             client_assertion:      `${assertion.jwt.slice(0, 40)}… (RS256-signed JWT)`,
             ...(ref ? { authorization_details: '…' } : {}),
+            ...(resource ? { resource } : {}),
           },
         });
 
@@ -282,6 +301,27 @@ client_assertion=<signed JWT ↓>`
                   {`[{"type":"umzh-connect-context","identifier":"${contextRef.trim()}"}]`}
                 </code>
                 {' '}→ JWT will carry <code>fhirContext</code> claim for OPA consent lookup.
+              </p>
+            )}
+          </div>
+
+          {/* RFC 8707 Resource Indicator */}
+          <div className="col-span-2">
+            <label className="block text-xs font-medium text-gray-500 mb-1">
+              Resource <span className="font-normal text-gray-400 ml-1">(RFC 8707 — restricts <code>aud</code> to this URI; clear to omit, use an unknown URI to test rejection)</span>
+            </label>
+            <input
+              type="text"
+              value={resourceUri}
+              onChange={e => setResourceUri(e.target.value)}
+              placeholder="e.g. http://localhost:8083"
+              className="block w-full p-2 border border-gray-300 rounded font-mono text-sm
+                         focus:outline-none focus:ring-2 focus:ring-blue-400"
+            />
+            {resourceUri.trim() && (
+              <p className="mt-1 text-xs text-blue-600">
+                Adds <code className="bg-blue-50 px-1 rounded">resource={resourceUri.trim()}</code>
+                {' '}→ token <code>aud</code> will be restricted to this URI only.
               </p>
             )}
           </div>

--- a/web-app/src/services/l2-signing.ts
+++ b/web-app/src/services/l2-signing.ts
@@ -103,6 +103,12 @@ export interface AcquireM2mTokenOptions {
    * are not fhirContext-gated.
    */
   fhirContextRef?: string;
+  /**
+   * RFC 8707 resource indicator — the base URL of the target resource server
+   * (e.g. "http://localhost:8083"). Restricts the token's aud claim to that
+   * resource server only.
+   */
+  resource?: string;
   onLog?: LogCallback;
 }
 
@@ -111,7 +117,7 @@ export interface AcquireM2mTokenOptions {
  * Fetch key → import → sign assertion → POST to Keycloak → access_token.
  */
 export async function acquireM2mToken(opts: AcquireM2mTokenOptions): Promise<string> {
-  const { keycloakTokenUrl, clientId, kid, keyUrl, fhirContextRef, onLog } = opts;
+  const { keycloakTokenUrl, clientId, kid, keyUrl, fhirContextRef, resource, onLog } = opts;
 
   onLog?.({ type: 'request', method: 'GET', url: keyUrl, message: 'Fetch L2 private key' });
   const keyRes = await fetch(keyUrl);
@@ -133,6 +139,9 @@ export async function acquireM2mToken(opts: AcquireM2mTokenOptions): Promise<str
     body.set('authorization_details',
       JSON.stringify([{ type: 'umzh-connect-context', identifier: fhirContextRef }]));
   }
+  if (resource) {
+    body.set('resource', resource);
+  }
 
   onLog?.({
     type: 'request', method: 'POST', url: keycloakTokenUrl,
@@ -143,6 +152,7 @@ export async function acquireM2mToken(opts: AcquireM2mTokenOptions): Promise<str
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
       client_assertion: `${assertion.jwt.slice(0, 40)}… (RS256-signed JWT)`,
       ...(fhirContextRef ? { authorization_details: `fhirContext=${fhirContextRef}` } : {}),
+      ...(resource ? { resource } : {}),
     },
   });
 


### PR DESCRIPTION
Use Keycloak's experimental resource-indicators feature so a single M2M client targets a specific partner gateway via the `resource` parameter, rather than minting one client per audience.

- docker-compose: enable --features=resource-indicators; pass gateway URLs
- realm: register placer/fulfiller external gateways as resource-server clients (resource_url), add an oidc-audience-mapper to each requesting client, and set client_credentials.use_refresh_token=true to work around the refresh-token NPE (keycloak#50251)
- get-token.sh / web-app: send resource=<partner gateway> on token requests
- tests: add 12-resource-indicators.hurl (valid -> 200; unknown and registered-but-unauthorized -> invalid_target)

Implements the sandbox side of umzhconnect-ig#75.

Closes #30